### PR TITLE
MNT: Add support for osx-64 builds

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,6 +8,9 @@ jobs:
     vmImage: macOS-13
   strategy:
     matrix:
+      osx_64_:
+        CONFIG: osx_64_
+        UPLOAD_PACKAGES: 'True'
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,0 +1,20 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '10.13'
+MACOSX_SDK_VERSION:
+- '10.13'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '10.13'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+fortran_compiler:
+- gfortran
+fortran_compiler_version:
+- '13'
+macos_machine:
+- x86_64-apple-darwin13.4.0
+target_platform:
+- osx-64

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24539&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/ff-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_arm64</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=24539&branchName=main">

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,9 @@ outputs:
         - sed -i "s|/usr/local/ff/|$PREFIX/share/ff/ |g" src/ff/ffinit.f
         - cat src/ff/ffinit.f
 
+        # DEBUG
+        - export FFLAGS="-isystem $PREFIX/include"  # [osx and x86]
+
         - cd src/ff
         - make install FC=$FC FFLAGS="$FFLAGS -std=legacy -ffixed-line-length-none" DEST=$PREFIX/lib --jobs="${CPU_COUNT}"
         - mkdir -p $PREFIX/include/ff

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,13 @@ source:
   sha256: 0f72c620bca93f62deed3194b56b34e66071c512cb8bc63be7aeedc35be7cbfc
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ name }}-static
 
     build:
-      skip: true  # [win or (osx and x86)]
+      skip: true  # [win]
       script:
         # FIXME: Patch out custom paths
         # Note: Need the space at the end of '$PREFIX/share/ff/ ' so that

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ outputs:
         # This is a bug and should get fixed by using better logic for fullname.
         - sed -i "s|/user/gj/lib/|$PREFIX/share/ff/ |g" src/ff/ffinit.f
         - sed -i "s|/usr/local/ff/|$PREFIX/share/ff/ |g" src/ff/ffinit.f
+        - cat src/ff/ffinit.f
 
         - cd src/ff
         - make install FC=$FC FFLAGS="$FFLAGS -std=legacy -ffixed-line-length-none" DEST=$PREFIX/lib --jobs="${CPU_COUNT}"


### PR DESCRIPTION
* Add osx-64 builds.
* ~~Change `-fstack-protector` FFLAGS flag to `-no-fstack-protector` for `x86` `osx` builds to allow for the `share/*.dat` files to be loaded properly. `osx-arm64` sets `-no-fstack-protector`, so this is mirroring that behavior.~~
   - ~~c.f. https://stackoverflow.com/questions/10712972/what-is-the-use-of-fno-stack-protector Having stack-protector enabled can break the ability to compile against non-standard userspace libraries, and can be considered harmful.~~
* Bump build number.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [N/A] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
